### PR TITLE
Fix Panic in webstorage/symbol-props.window.js

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5854,7 +5854,11 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
             if self.descriptor.hasLegacyUnforgeableMembers:
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
-            set += CGProxyNamedDeleter(self.descriptor).define()
+            set += (
+                "if id.is_string() || id.is_int() {\n"
+                + CGProxyNamedDeleter(self.descriptor).define()
+                + "}\n"
+            )
         set += "return proxyhandler::delete(*cx, %s);" % ", ".join(a.name for a in self.args[1:])
         return set
 

--- a/tests/wpt/meta/webstorage/symbol-props.window.js.ini
+++ b/tests/wpt/meta/webstorage/symbol-props.window.js.ini
@@ -1,2 +1,6 @@
 [symbol-props.window.html]
-  expected: CRASH
+  [localStorage: defineProperty not configurable]
+    expected: FAIL
+
+  [sessionStorage: defineProperty not configurable]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #

<!-- Either: -->
- [x] There are tests for these changes
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
